### PR TITLE
corrected value of CUSOLVER_EIG_MODE_VECTOR

### DIFF
--- a/JCusolverJava/src/main/java/jcuda/jcusolver/cusolverEigMode.java
+++ b/JCusolverJava/src/main/java/jcuda/jcusolver/cusolverEigMode.java
@@ -33,7 +33,7 @@ package jcuda.jcusolver;
 public class cusolverEigMode
 {
     public static final int CUSOLVER_EIG_MODE_NOVECTOR = 0;
-    public static final int CUSOLVER_EIG_MODE_VECTOR = 2;
+    public static final int CUSOLVER_EIG_MODE_VECTOR = 1;
 
     /**
      * Private constructor to prevent instantiation


### PR DESCRIPTION
Hi Marco,
thanks for the useful JCuda libraries and it helps me a lot. I met some bug when using JCusolver, and I found the reason finally, which is lead by the value of *CUSOLVER_EIG_MODE_VECTOR*. 

In JCuda, *CUSOLVER_EIG_MODE_VECTOR = 2*. However, I printed this value in Cuda, it shows that *CUSOLVER_EIG_MODE_VECTOR = 1*.  There will be a *CUSOLVER_STATUS_INVALID_VALUE* exception if directly passing *CUSOLVER_EIG_MODE_VECTOR* in JCuda to Cuda. For example, the method *cusolverDnDsyevd()* accepts *jobz* as an integer, If passing *CUSOLVER_EIG_MODE_VECTOR*, above exception will occur. So, in this pull request, I changed the value of *CUSOLVER_EIG_MODE_VECTOR* from 2 to 1, which will keep the same with Cuda library. 

Thanks again for your helpful contributions on those projects!

Cheers,
Zhiwei

